### PR TITLE
Allow override of custom content path variable

### DIFF
--- a/bash.env.sh
+++ b/bash.env.sh
@@ -2,7 +2,9 @@
 [[ -z "$PS1" ]] && return
 
 export dot_env_path="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export dot_env_custom="${dot_env_path}/custom"
+
+# Allow custom directory to exist outside of project root.
+export dot_env_custom="${dot_env_custom:=${dot_env_path}/custom}"
 
 # Display .env version
 if [[ "$SHLVL" == "1" ]]; then


### PR DESCRIPTION
I haven't found a good solution that allows for both contributing to your project and maintaining custom plugins within the forked repo. So, I think this may be a way around that.